### PR TITLE
Run "Test Ecosystem" workflow only when changing the workflow file

### DIFF
--- a/.github/workflows/test-ecosystem.yml
+++ b/.github/workflows/test-ecosystem.yml
@@ -3,7 +3,9 @@ name: Test Ecosystem
 on:
   push:
     branches: [main]
+    paths: ['.github/workflows/test-ecosystem.yml']
   pull_request:
+    paths: ['.github/workflows/test-ecosystem.yml']
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *' # Every day at 00:00 UTC


### PR DESCRIPTION
The workflow starts a lot of jobs. This is often a waste of CI resources.

Ref https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore
